### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then we can set an expression to define our desired values with a PUT request to
 {
     "*parameter": "k",
     "*property": "{products/<k>/name}"
-    "*value": "{products/<k>/stock}"
+    "*value": "{products/<k>/on_stock}"
 }
 ```
 


### PR DESCRIPTION
Fixed a typo (?). It is not clear from the story why /stock is relevant here. Does it exist to create a saving spot for expressions? (/expression/stock instead of /expression/product ?). The schema does not seem related?